### PR TITLE
bugfix: quote should be replaced in inline style

### DIFF
--- a/deps/katana-parser/src/katana_parser.c
+++ b/deps/katana-parser/src/katana_parser.c
@@ -89,6 +89,7 @@ static KatanaOutput* katana_parse_fragment(const char* prefix,
 
 static const char* katana_stringify_value_list(KatanaParser* parser, KatanaArray* value_list);
 static const char* katana_stringify_value(KatanaParser* parser, KatanaValue* value);
+static bool katana_string_contain_space(const char *s);
 
 static void* malloc_wrapper(void* unused, size_t size) {
     return malloc(size);
@@ -1639,7 +1640,7 @@ static const char* katana_stringify_value_list(KatanaParser* parser, KatanaArray
 static const char* katana_stringify_value(KatanaParser* parser, KatanaValue* value)
 {
     // TODO: @(QFish) Handle this more gracefully X).
-    char str[256];
+    char str[256] = {0};
 
     switch (value->unit) {
         case KATANA_VALUE_NUMBER:
@@ -1672,8 +1673,13 @@ static const char* katana_stringify_value(KatanaParser* parser, KatanaValue* val
             break;
         case KATANA_VALUE_STRING:
             // FIXME: @(QFish) Do we need double quote or not ?
-//            snprintf(str, sizeof(str), "\"%s\"", value->string);
-            snprintf(str, sizeof(str), "%s", value->string);
+            // FIXED: @(detailyang) append quote only contain space !
+
+            if (katana_string_contain_space(value->string) == true) {
+                snprintf(str, sizeof(str), "\"%s\"", value->string);
+            } else {
+                snprintf(str, sizeof(str), "%s", value->string);
+            }
             break;
         case KATANA_VALUE_PARSER_FUNCTION:
         {
@@ -1708,4 +1714,16 @@ static const char* katana_stringify_value(KatanaParser* parser, KatanaValue* val
     strcpy(dest, str);
     dest[len] = '\0';
     return dest;
+}
+
+
+static bool katana_string_contain_space(const char *s)
+{
+    for (;*s; s++) {
+        if(isspace(*s)) {
+            return true;
+        }
+    }
+
+    return false;
 }

--- a/t/006-html-sanitize_style_property.t
+++ b/t/006-html-sanitize_style_property.t
@@ -68,3 +68,93 @@ location /t {
 <h1 style=\"color:red;text-align:center;font-size:12pt !important;background-image: expression(alert(1));\">h1</h1>
 "
 --- response_body: <h1 style="color:red;font-size:12pt !important;background-image:expression(alert(1));">h1</h1>
+
+
+
+=== test 5: html_sanitize_style_property "'" when style_property_value is 0
+--- config
+location /t {
+    html_sanitize on;
+    html_sanitize_attribute h1.style;
+    html_sanitize_style_property font-family;
+}
+--- request eval
+"POST /t?element=1&attribute=2&style_property=1&style_property_value=0
+<h1 style=\"font-family: 'Microsoft Yahei';\">h1</h1>
+"
+--- response_body: <h1 style="font-family: 'Microsoft Yahei';">h1</h1>
+
+
+
+=== test 6: html_sanitize_style_property """ when style_property_value is 0
+--- config
+location /t {
+    html_sanitize on;
+    html_sanitize_attribute h1.style;
+    html_sanitize_style_property font-family;
+}
+--- request eval
+"POST /t?element=1&attribute=2&style_property=1&style_property_value=0
+<h1 style='font-family: \"Microsoft Yahei\";\'>h1</h1>
+"
+--- response_body: <h1 style='font-family: "Microsoft Yahei";'>h1</h1>
+
+
+
+=== test 7: html_sanitize_style_property &quot; when style_property_value is 0
+--- config
+location /t {
+    html_sanitize on;
+    html_sanitize_attribute h1.style;
+    html_sanitize_style_property font-family;
+}
+--- request eval
+"POST /t?element=1&attribute=2&style_property=1&style_property_value=0
+<h1 style=\"font-family: &quot;Microsoft Yahei&quot;;\">h1</h1>
+"
+--- response_body: <h1 style="font-family: 'Microsoft Yahei';">h1</h1>
+
+
+
+=== test 8: html_sanitize_style_property "'" when style_property_value is 1
+--- config
+location /t {
+    html_sanitize on;
+    html_sanitize_attribute h1.style;
+    html_sanitize_style_property font-family;
+}
+--- request eval
+"POST /t?element=1&attribute=2&style_property=1&style_property_value=1
+<h1 style=\"font-family: 'Microsoft Yahei';\">h1</h1>
+"
+--- response_body: <h1 style="font-family:'Microsoft Yahei';">h1</h1>
+
+
+
+=== test 9: html_sanitize_style_property &quot; when style_property_value is 1
+--- config
+location /t {
+    html_sanitize on;
+    html_sanitize_attribute h1.style;
+    html_sanitize_style_property font-family;
+}
+--- request eval
+"POST /t?element=1&attribute=2&style_property=1&style_property_value=1
+<h1 style=\"font-family: &quot;Microsoft Yahei&quot;;\">h1</h1>
+"
+--- response_body: <h1 style="font-family:'Microsoft Yahei';">h1</h1>
+
+
+
+=== test 10: html_sanitize_style_property """ when style_property_value is 1
+--- config
+location /t {
+    html_sanitize on;
+    html_sanitize_attribute h1.style;
+    html_sanitize_style_property font-family;
+}
+--- request eval
+"POST /t?element=1&attribute=2&style_property=1&style_property_value=1
+<h1 style='font-family: \"Microsoft Yahei\";\'>h1</h1>
+"
+--- response_body: <h1 style='font-family:"Microsoft Yahei";'>h1</h1>


### PR DESCRIPTION
When quote be escaped in html entities in inline style, now it will be translated to original quote whatever attributes's quote.

Here it's a trick to avoid this bugly behavior as the following:
* `"font-family: \"Microsoft Yahei\";" => "font-family: 'Microsoft Yahei';"`
* `'font-family: \"Microsoft Yahei\";' => 'font-family: "Microsoft Yahei";'`
