### PR TITLE
Allow compiling with GCC 8

### DIFF
--- a/config
+++ b/config
@@ -64,7 +64,7 @@ if test -n "$ngx_module_link"; then
     ngx_module_deps="$NGX_HTTP_HTML_SANITIZE_DEPS"
     ngx_module_srcs="$NGX_HTTP_HTML_SANITIZE_SRCS"
 
-    CFLAGS="$CFLAGS -std=gnu99 -g -O2 -fno-omit-frame-pointer"
+    CFLAGS="$CFLAGS -std=gnu99 -g -O2 -fno-omit-frame-pointer -Wno-implicit-fallthrough -Wno-misleading-indentation"
 
     . auto/module
 
@@ -74,5 +74,5 @@ else
     NGX_ADDON_DEPS="$NGX_HTTP_HTML_SANITIZE_DPES"
     CORE_INCS="$CORE_INCS $NGX_HTTP_HTML_SANITIZE_INCS"
 
-    CFLAGS="$CFLAGS -std=gnu99 -g -O2 -fno-omit-frame-pointer"
+    CFLAGS="$CFLAGS -std=gnu99 -g -O2 -fno-omit-frame-pointer -Wno-implicit-fallthrough -Wno-misleading-indentation"
 fi


### PR DESCRIPTION
Looks like GCC 8 has some extra switches that cause failure while compiling the module with it. Added bypassing treating those warnings as errors. Verified that it's still ok  with both GCC 4 and 8